### PR TITLE
Refactor getOpFromUrl to use URL object parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,5 @@
 ## Changelog
 
-### Version 1.3.0
-* Add a setting to send mod mail notifications when a new version of Picture Police is published
-* Add a setting to exclude mods from all Picture Police scans
-* Reduce false positives on partial matches when only direct Reddit image links are found
-* Change all external (non-Reddit) website links to direct-image links
-* Fix bug preventing action summaries from being sent
-* Change OP whitelist mod menu item to a toggle and add app name to label
-
-### Version 1.2.2
-* Merge pull request #27 from ninetySixDPI/dev
-
 ### Version 1.2.1
 * Fix an issue where the wrong Reddit URLs were being added to the match list.
 * Add a new installation setting to set a minimum confidence score at which mod actions will be completed.

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -8,4 +8,10 @@ export const APP_CHANGELOG: Record<string, string[]> =
         "Fix bug preventing action summaries from being sent",
         "Change OP whitelist mod menu item to a toggle and add app name to label"
     ],
+    "1.3.1": [
+        "Change confidence threshold default setting to 51",
+        "Remove query strings from direct image URLs",
+        "Support Reddit Gallery (\"redditery.com\") URLs for matching images",
+        "Change destination on comment feedback links to send to mod mail"
+    ],
 };

--- a/src/gvis.ts
+++ b/src/gvis.ts
@@ -30,7 +30,12 @@ export async function checkGoogleVision(imgUrl: string, apiKey: string)
             });
 
         const data = await response.json();
-        // console.debug(`WEB_DETECTION result:\n\n${JSON.stringify(data.responses[0].webDetection, null, 2)}`);
+        // const pagesWithMatchingImages = data.responses[0].webDetection.pagesWithMatchingImages;
+        // for (const page of pagesWithMatchingImages)
+        // {
+        //     console.debug(JSON.stringify(page, null, 2));
+        // }
+        // console.debug(`WEB_DETECTION result:\n\n${JSON.stringify(data.responses[0].webDetection.pagesWithMatchingImages, null, 2)}`);
         return data.responses[0].webDetection;
     }
     catch (e)

--- a/src/main.ts
+++ b/src/main.ts
@@ -92,7 +92,7 @@ Devvit.addSettings([
                 name: "CONFIDENCE_THRESHOLD",
                 label: "Confidence threshold",
                 helpText: "A confidence score BELOW this number will not trigger any mod notifications or mod actions. Comments (if enabled) will still be made.",
-                defaultValue: 50
+                defaultValue: 51
             },
             {
                 type: "boolean",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,14 +28,34 @@ export async function getOpFromUrl(
     url: string,
     reddit: RedditAPIClient): Promise<string | undefined>
 {
-    // FIXME this should use the URL Object (new URL)
-    const match = url.match(/\/comments\/([a-z0-9]+)/i);
-    if (!match)
+    let id: string | undefined;
+    try
+    {
+        const urlObj = new URL(url);
+        const parts = urlObj.pathname.split('/');
+        const commentsIndex = parts.findIndex(p => p.toLowerCase() === 'comments');
+
+        if (commentsIndex !== -1 && commentsIndex + 1 < parts.length)
+        {
+            const segment = parts[commentsIndex + 1];
+            const match = segment.match(/^([a-z0-9]+)/i);
+            if (match)
+            {
+                id = match[1];
+            }
+        }
+    }
+    catch (e)
     {
         return undefined;
     }
 
-    const postId = `t3_${match[1]}`;
+    if (!id)
+    {
+        return undefined;
+    }
+
+    const postId = `t3_${id}`;
     try
     {
         const post = await reddit.getPostById(postId);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,8 +6,11 @@ export const PROBABLE_MATCH_KEY = "stats:daily_probable_match";
 export const SCAN_KEY = "stats:daily_scans";
 export const MIN_CONF = 50; // a score BELOW this number is considered NOT confident
 
+const POST_ID_TOKEN = "[POST_ID_TOKEN]";
+const SUB_TOKEN = "[SUB_TOKEN]";
 const URL_TOKEN = "[URL_TOKEN]";
-const MAIL_LINK = `[Click here to submit feedback](https://www.reddit.com/message/compose/?to=96dpi&subject=Picture%20Police%20Feedback&message=Regarding%20post:%20${URL_TOKEN})`;
+const COMMENT_FEEDBACK_LINK = `[Click here to submit feedback](https://www.reddit.com/message/compose?to=r/${SUB_TOKEN}&subject=Picture%20Police%20Feedback&message=Regarding%20post:%20/r/${SUB_TOKEN}/comments/${POST_ID_TOKEN})`;
+const MOD_MAIL_FEEDBACK_LINK = `[Click here to submit feedback](https://www.reddit.com/message/compose/?to=96dpi&subject=Picture%20Police%20Feedback&message=Regarding%20post:%20${URL_TOKEN})`;
 const DISCLAIMER = `**Note:** Click on external links at your own risk. This `+
     `bot does not guarantee the security of any external websites you visit.`;
 
@@ -164,12 +167,12 @@ export async function comment(
     const ocCommentStrSingular = `🚨 **Picture Police** 🚨\n\n` +
         `This image appears to be u/${authorName}'s original content. I could `+
         `not find any matching images anywhere on the web.\n\n`+
-        `---\n\n${MAIL_LINK}`;
+        `---\n\n${COMMENT_FEEDBACK_LINK}`;
 
     const ocCommentStrPlural = `🚨 **Picture Police** 🚨\n\n` +
         `These images appear to be u/${authorName}'s original content. I could `+
         `not find any matching images anywhere on the web.\n\n`+
-        `---\n\n${MAIL_LINK}`;
+        `---\n\n${COMMENT_FEEDBACK_LINK}`;
 
     const possibleOcCommentStrSingular = `🚨 **Picture Police** 🚨\n\n` +
         `I am only **${maxScore}%** confident that this is a **stolen** image. `+
@@ -187,13 +190,13 @@ export async function comment(
         `I am **${maxScore}%** confident that this is a **stolen** image. ` +
         `I found the same image on **${totalMatchCount}** other site(s). ` +
         `Here is an example of what I found:\n\n `+
-        `${urlStr}${DISCLAIMER}\n\n---\n\n${MAIL_LINK}`;
+        `${urlStr}${DISCLAIMER}\n\n---\n\n${COMMENT_FEEDBACK_LINK}`;
 
     const stolenCommentStrPlural = `🚨 **Picture Police** 🚨\n\n` +
         `I am **${maxScore}%** confident that this post contains **stolen** ` +
         `images. I found duplicate images on **${totalMatchCount}** other ` +
         `sites. Here is an example of each image found on another site:\n\n `+
-        `${urlStr}${DISCLAIMER}\n\n---\n\n${MAIL_LINK}`;
+        `${urlStr}${DISCLAIMER}\n\n---\n\n${COMMENT_FEEDBACK_LINK}`;
 
     const isOc = maxScore <= 0;
     const possibleOc = !isOc && maxScore < MIN_CONF;
@@ -227,9 +230,12 @@ export async function comment(
         commentStr = stolenCommentStrPlural;
     }
 
+    commentStr = commentStr.replaceAll(SUB_TOKEN, context.subredditName);
+    commentStr = commentStr.replace(POST_ID_TOKEN, postId.replace("t3_", ""));
+
     const comment = await context.reddit.submitComment({
         id: postId,
-        text: commentStr.replace(URL_TOKEN, postId)
+        text: commentStr
     });
 
     if (comment)
@@ -359,7 +365,7 @@ export async function sendModMail(
             `**Matches:** ${numMatches}\n\n`+
             `**Score:** ${maxScore}%\n\n`+
             `**Example ${matchStr}:**\n\n${urlStr}\n\n---\n\n`+
-            `${MAIL_LINK.replace(URL_TOKEN, url)}`;
+            `${MOD_MAIL_FEEDBACK_LINK.replace(URL_TOKEN, url)}`;
 
         const modMailId = await context.reddit.modMail.createModNotification({
             subject: "🚨 Picture Police Report 🚨",
@@ -572,6 +578,19 @@ export function isRedditAsset(url: string): boolean
     const urlObj = new URL(url);
     return urlObj.hostname.endsWith("redditmedia.com") ||
            urlObj.hostname.endsWith("redditstatic.com");
+}
+
+export function stripQueryString(urlStr: string): string
+{
+    try
+    {
+        const urlObj = new URL(urlStr);
+        return `${urlObj.origin}${urlObj.pathname}`;
+    }
+    catch (error)
+    {   // don't change anything on error, malformed URL
+        return urlStr;
+    }
 }
 
 // function getTimeDifference(originalPostDate: string, matchingPostDate: string)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,11 @@
   "extends": "@devvit/public-api/devvit.tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
+    "lib": [
+      "ESNext",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "ESNext",
     "moduleResolution": "node",
     "types": ["node"],


### PR DESCRIPTION
Refactored `getOpFromUrl` in `src/utils.ts` to use the `URL` object for parsing the post ID instead of a regular expression. This change improves the robustness of URL parsing and ensures valid handling of various URL formats. Verified the logic with a test script and ensured no TypeScript errors were introduced.

---
*PR created automatically by Jules for task [5025916657854709162](https://jules.google.com/task/5025916657854709162) started by @ninetySixDPI*